### PR TITLE
fix issues with wrong ScanNet aggregation file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+data/PointGroupInst/
+data/scannet/__pycache__/
+data/scannet/scans

--- a/data/scannet/prepare_data.py
+++ b/data/scannet/prepare_data.py
@@ -165,7 +165,8 @@ def export(mesh_file, agg_file, seg_file, meta_file, label_map_file, output_file
 
 def export_one_scan(scan_name, output_filename_prefix):
     mesh_file = os.path.join(SCANNET_DIR, scan_name, scan_name + '_vh_clean_2.ply')
-    agg_file = os.path.join(SCANNET_DIR, scan_name, scan_name + '_vh_clean.aggregation.json')
+    # agg_file = os.path.join(SCANNET_DIR, scan_name, scan_name + '_vh_clean.aggregation.json')
+    agg_file = os.path.join(SCANNET_DIR, scan_name, scan_name + '.aggregation.json') # NOTE must use the aggregation file for the low-res mesh
     seg_file = os.path.join(SCANNET_DIR, scan_name, scan_name + '_vh_clean_2.0.010000.segs.json')
 
     meta_file = os.path.join(SCANNET_DIR, scan_name,


### PR DESCRIPTION
Hi there,

the original `_vh_clean.aggregation.json` is for the high-res mesh files - I've corrected it to `.aggregation.json` which matches the low-res files you use in this repo. 

(plz check [ScanNet README](https://github.com/ScanNet/ScanNet#data-organization))

Best
Dave